### PR TITLE
Fixes and improvements

### DIFF
--- a/autoload/omni/cpp/includes.vim
+++ b/autoload/omni/cpp/includes.vim
@@ -45,10 +45,12 @@ function! s:GetIncludeListFromCurrentBuffer()
 
     call setpos('.', [0, 1, 1, 0])
     let curPos = [1,1]
+    let wrapFlg = 'cW'
     let alreadyInclude = {}
     while curPos != [0,0]
-        let curPos = searchpos('\C\(^'.s:rePreprocIncludeFile.'\)', 'W')
+        let curPos = searchpos('\C\(^'.s:rePreprocIncludeFile.'\)', wrapFlg)
         if curPos != [0,0]
+            let wrapFlg = 'W'
             let szLine = getline('.')
             let startPos = curPos[1]
             let endPos = matchend(szLine, s:reIncludeFilePart, startPos-1)

--- a/autoload/omni/cpp/includes.vim
+++ b/autoload/omni/cpp/includes.vim
@@ -60,7 +60,7 @@ function! s:GetIncludeListFromCurrentBuffer()
                 let szResolvedInclude = omni#cpp#utils#ResolveFilePath(szIncludeFile)
 
                 " Protection over self inclusion
-                if szResolvedInclude != '' && szResolvedInclude != omni#cpp#utils#ResolveFilePath(getreg('%'))
+                if szResolvedInclude != '' && szResolvedInclude != fnameescape(expand("%:p"))
                     let includePos = curPos
                     if !has_key(alreadyInclude, szResolvedInclude)
                         call extend(listIncludes, [{'pos' : includePos, 'include' : szResolvedInclude}])

--- a/autoload/omni/cpp/items.vim
+++ b/autoload/omni/cpp/items.vim
@@ -380,6 +380,12 @@ function! s:GetTypeInfoOfReturnedType(contextStack, szFunctionName)
 
     if tagItem != {}
         let szCmdWithoutVariable = substitute(omni#cpp#utils#ExtractCmdFromTagItem(tagItem), '\C\<'.a:szFunctionName.'\>.*', '', 'g')
+
+        " If it is a constructor, return the class name as function type
+        if szCmdWithoutVariable == ""
+            return {'type': 1, 'value': a:szFunctionName}
+        endif
+
         let tokens = omni#cpp#tokenizer#Tokenize(omni#cpp#utils#GetCodeFromLine(szCmdWithoutVariable))
         let result = omni#cpp#utils#CreateTypeInfo(omni#cpp#utils#ExtractTypeInfoFromTokens(tokens))
         " TODO: Namespace resolution for result

--- a/autoload/omni/cpp/namespaces.vim
+++ b/autoload/omni/cpp/namespaces.vim
@@ -203,7 +203,7 @@ function! s:GetAllUsingNamespaceMapFromCurrentBuffer(...)
     let includeGuard = (a:0>0)? a:1 : {}
 
     let szBufferName = getreg("%")
-    let szFilePath = omni#cpp#utils#ResolveFilePath(szBufferName)
+    let szFilePath = fnameescape(expand("%:p"))
     let szFilePath = (szFilePath=='')? szBufferName : szFilePath
 
     let namespaceMap = {}

--- a/autoload/omni/cpp/namespaces.vim
+++ b/autoload/omni/cpp/namespaces.vim
@@ -283,9 +283,11 @@ function! omni#cpp#namespaces#GetMapFromCurrentBuffer()
 
     call setpos('.', [0, 1, 1, 0])
     let curPos = [1,1]
+    let wrapFlg = 'cW'
     while curPos != [0,0]
-        let curPos = searchpos('\C^using\s\+namespace', 'W')
+        let curPos = searchpos('\C^using\s\+namespace', wrapFlg)
         if curPos != [0,0]
+            let wrapFlg = 'W'
             let szLine = getline('.')
             let startPos = curPos[1]
             let endPos = match(szLine, ';', startPos-1)


### PR DESCRIPTION
#4a61a74
If you have "using namespace" or "#include" in the 1st line of your source code, it was not detected. 

#81dd7d1
Searching files by omni#cpp#utils#ResolveFilePath is slow, at least on Windows machines. To get the full path of the current buffer I used a built in method. This improves the performance if you have set OmniCpp_NamespaceSearch = 1.

#93d65b2
I added a change to complete something like "myClass().<CTRL-X><CTRL-O>".
